### PR TITLE
Updated link to Etherpad

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ https://github.com/whid-injector/WHID
 
 ### Software For Team Communication
 * **RocketChat** is free, unlimited and open source. Replace email & Slack with the ultimate team chat software solution. https://rocket.chat
-* **Etherpad** is an open source, web-based collaborative real-time editor, allowing authors to simultaneously edit a text document https://etherpad.net
+* **Etherpad** is an open source, web-based collaborative real-time editor, allowing authors to simultaneously edit a text document https://etherpad.org/
 
 ### Log Aggregation
 * **RedELK** Red Team's SIEM - easy deployable tool for Red Teams used for tracking and alarming about Blue Team activities as well as better usability in long term operations. https://github.com/outflanknl/RedELK/


### PR DESCRIPTION
Updated link to Etherpad from etherpad.net -> etherpad.org as the former has been shut down.