### PR TITLE
Add ProjectDiscovery recon tools: nuclei, subfinder, httpx, naabu

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ This repository contains cutting-edge open-source security tools (OST) that will
 |LinkedInt|LinkedIn Recon Tool|https://github.com/vysecurity/LinkedInt|
 |BBOT|Recursive internet scanner inspired by Spiderfoot, but designed to be faster, more reliable, and friendlier to pentesters, bug bounty hunters, and developers.|https://github.com/blacklanternsecurity/bbot|
 |Gato (Github Attack TOolkit)|Gato, or GitHub Attack Toolkit, is an enumeration and attack tool that allows both blue teamers and offensive security practitioners to identify and exploit pipeline vulnerabilities within a GitHub organization's public and private repositories.|https://github.com/praetorian-inc/gato|
+|nuclei|Fast and customizable vulnerability scanner based on templates. Nuclei offers a large number of templates for detecting CVEs, misconfigurations, and exposed services.|https://github.com/projectdiscovery/nuclei|
+|subfinder|Fast passive subdomain enumeration tool that discovers valid subdomains for websites by using passive online sources and certificates.|https://github.com/projectdiscovery/subfinder|
+|httpx|Fast and multi-purpose HTTP toolkit that allows running multiple probes using the retryablehttp library.|https://github.com/projectdiscovery/httpx|
+|naabu|Fast port scanner with a focus on reliability and simplicity. Designed to be used in combination with other ProjectDiscovery tools.|https://github.com/projectdiscovery/naabu|
 
 ## Initial Access
 


### PR DESCRIPTION
## Description

Added 4 essential **ProjectDiscovery** reconnaissance tools to the Reconnaissance section:

### Added:
| Tool | Description | Stars |
|------|-------------|-------|
| **nuclei** | Fast and customizable vulnerability scanner based on templates. Detects CVEs, misconfigurations, and exposed services. | 21k+ |
| **subfinder** | Fast passive subdomain enumeration tool using passive online sources and certificates. | 10k+ |
| **httpx** | Fast and multi-purpose HTTP toolkit for running multiple probes. | 8k+ |
| **naabu** | Fast port scanner focused on reliability and simplicity. | 5k+ |

### Why:
ProjectDiscovery tools have become the **de facto standard** for modern reconnaissance and vulnerability scanning. They are widely used by:
- Red team operators for attack surface mapping
- Bug bounty hunters for reconnaissance
- Penetration testers for automated vulnerability assessment

These tools integrate seamlessly with each other (subfinder -> httpx -> nuclei pipeline) and are actively maintained with regular updates.

## Checklist
- [x] Format matches existing table entries
- [x] Tools are actively maintained and open source
- [x] No duplicates (verified none of these were already listed)