### PR TITLE
Add NetExec, Certipy, Caido, and Censys tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ This repository contains cutting-edge open-source security tools (OST) that will
 |subfinder|Fast passive subdomain enumeration tool that discovers valid subdomains for websites by using passive online sources and certificates.|https://github.com/projectdiscovery/subfinder|
 |httpx|Fast and multi-purpose HTTP toolkit that allows running multiple probes using the retryablehttp library.|https://github.com/projectdiscovery/httpx|
 |naabu|Fast port scanner with a focus on reliability and simplicity. Designed to be used in combination with other ProjectDiscovery tools.|https://github.com/projectdiscovery/naabu|
+|Caido|A lightweight, modern web security auditing toolkit and proxy. Next-generation alternative to Burp Suite with AI-powered features.|https://github.com/caido/caido|
+|Censys Subdomain Finder|Enumerate subdomains using the Censys API. Useful for passive reconnaissance and attack surface discovery.|https://github.com/christophetd/censys-subdomain-finder|
 
 ## Initial Access
 
@@ -307,6 +309,8 @@ This repository contains cutting-edge open-source security tools (OST) that will
 |SharpSploit|SharpSploit is a .NET post-exploitation library written in C# that aims to highlight the attack surface of .NET and make the use of offensive .NET easier for red teamers.|https://github.com/cobbr/SharpSploit|
 |orpheus|Bypassing Kerberoast Detections with Modified KDC Options and Encryption Types|https://github.com/trustedsec/orpheus|
 |goexec|GoExec is a new take on some of the methods used to gain remote execution on Windows devices. GoExec implements a number of largely unrealized execution methods and provides significant OPSEC improvements overall.|https://github.com/FalconOpsLLC/goexec|
+|NetExec|The Network Execution Tool - a modern successor to CrackMapExec with enhanced features for network security assessment and post-exploitation.|https://github.com/Pennyw0rth/NetExec|
+|Certipy|Tool for Active Directory Certificate Services enumeration and abuse. Supports certificate theft, escalation, and persistence through AD CS.|https://github.com/ly4k/Certipy|
 |BitlockMove|Lateral Movement via Bitlocker DCOM interfaces & COM Hijacking|https://github.com/rtecCyberSec/BitlockMove|
 
 ### Tunneling

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ This repository contains cutting-edge open-source security tools (OST) that will
 |LinkedInt|LinkedIn Recon Tool|https://github.com/vysecurity/LinkedInt|
 |BBOT|Recursive internet scanner inspired by Spiderfoot, but designed to be faster, more reliable, and friendlier to pentesters, bug bounty hunters, and developers.|https://github.com/blacklanternsecurity/bbot|
 |Gato (Github Attack TOolkit)|Gato, or GitHub Attack Toolkit, is an enumeration and attack tool that allows both blue teamers and offensive security practitioners to identify and exploit pipeline vulnerabilities within a GitHub organization's public and private repositories.|https://github.com/praetorian-inc/gato|
+|nuclei|Fast and customizable vulnerability scanner based on templates. Nuclei offers a large number of templates for detecting CVEs, misconfigurations, and exposed services.|https://github.com/projectdiscovery/nuclei|
+|subfinder|Fast passive subdomain enumeration tool that discovers valid subdomains for websites by using passive online sources and certificates.|https://github.com/projectdiscovery/subfinder|
+|httpx|Fast and multi-purpose HTTP toolkit that allows running multiple probes using the retryablehttp library.|https://github.com/projectdiscovery/httpx|
+|naabu|Fast port scanner with a focus on reliability and simplicity. Designed to be used in combination with other ProjectDiscovery tools.|https://github.com/projectdiscovery/naabu|
 
 ## Initial Access
 


### PR DESCRIPTION
## Description

Added 4 new cutting-edge security tools to the toolkit:

### Reconnaissance:
1. **[Caido](https://github.com/caido/caido)** - A lightweight, modern web security auditing toolkit and proxy. Next-generation alternative to Burp Suite with AI-powered features for web application security testing.
2. **[Censys Subdomain Finder](https://github.com/christophetd/censys-subdomain-finder)** - Enumerate subdomains using the Censys API. Useful for passive reconnaissance and attack surface discovery.

### Lateral Movement:
3. **[NetExec](https://github.com/Pennyw0rth/NetExec)** - The Network Execution Tool, a modern and actively maintained successor to CrackMapExec (which is archived). Enhanced features for network security assessment and post-exploitation with support for SMB, LDAP, MSSQL, SSH, WinRM, FTP, and more.
4. **[Certipy](https://github.com/ly4k/Certipy)** - Tool for Active Directory Certificate Services (AD CS) enumeration and abuse. Supports certificate theft, privilege escalation, and persistence through AD CS. AD CS attacks are increasingly critical in red team operations.

### Why:
- **NetExec**: CrackMapExec is archived and no longer maintained. NetExec is the community-driven successor with active development.
- **Certipy**: AD CS attacks have become one of the most important attack vectors in Active Directory environments since the SpecterOps Certified Pre-Owned research.
- **Caido**: Modern alternative to Burp Suite that is gaining rapid adoption in the security community.
- **Censys**: Complements existing OSINT tools for comprehensive reconnaissance.

## Checklist
- [x] Format matches existing table entries
- [x] Tools are actively maintained and open-source
- [x] Tools are relevant to red team operations